### PR TITLE
NEW: [RFP-13] Adds GovernorBravo contracts

### DIFF
--- a/contracts/GovernorBravo.sol
+++ b/contracts/GovernorBravo.sol
@@ -1,0 +1,432 @@
+pragma solidity ^0.5.16;
+pragma experimental ABIEncoderV2;
+
+import "./GovernorBravoInterfaces.sol";
+
+contract GovernorBravoDelegate is GovernorBravoDelegateStorageV2, GovernorBravoEvents {
+
+    /// @notice The name of this contract
+    string public constant name = "Idle Governor Bravo";
+
+    /// @notice The minimum setable proposal threshold
+    uint public constant MIN_PROPOSAL_THRESHOLD = 65000e18; // 65,000 Idle
+
+    /// @notice The maximum setable proposal threshold
+    uint public constant MAX_PROPOSAL_THRESHOLD = 130000e18; //130,000 Idle
+
+    /// @notice The minimum setable voting period
+    uint public constant MIN_VOTING_PERIOD = 5760; // About 24 hours
+
+    /// @notice The max setable voting period
+    uint public constant MAX_VOTING_PERIOD = 80640; // About 2 weeks
+
+    /// @notice The min setable voting delay
+    uint public constant MIN_VOTING_DELAY = 1;
+
+    /// @notice The max setable voting delay
+    uint public constant MAX_VOTING_DELAY = 40320; // About 1 week
+
+    /// @notice The number of votes in support of a proposal required in order for a quorum to be reached and for a vote to succeed
+    uint public constant quorumVotes = 520000e18; // 520,000 = 4% of Idle
+
+    /// @notice The maximum number of actions that can be included in a proposal
+    uint public constant proposalMaxOperations = 10; // 10 actions
+
+    /// @notice The EIP-712 typehash for the contract's domain
+    bytes32 public constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+
+    /// @notice The EIP-712 typehash for the ballot struct used by the contract
+    bytes32 public constant BALLOT_TYPEHASH = keccak256("Ballot(uint256 proposalId,uint8 support)");
+
+    /**
+      * @notice Used to initialize the contract during delegator contructor
+      * @param timelock_ The address of the Timelock
+      * @param idle_ The address of the IDLE token
+      * @param votingPeriod_ The initial voting period
+      * @param votingDelay_ The initial voting delay
+      * @param proposalThreshold_ The initial proposal threshold
+      */
+    function initialize(address timelock_, address idle_, uint votingPeriod_, uint votingDelay_, uint proposalThreshold_) public {
+        require(address(timelock) == address(0), "GovernorBravo::initialize: can only initialize once");
+        require(msg.sender == admin, "GovernorBravo::initialize: admin only");
+        require(timelock_ != address(0), "GovernorBravo::initialize: invalid timelock address");
+        require(idle_ != address(0), "GovernorBravo::initialize: invalid idle address");
+        require(votingPeriod_ >= MIN_VOTING_PERIOD && votingPeriod_ <= MAX_VOTING_PERIOD, "GovernorBravo::initialize: invalid voting period");
+        require(votingDelay_ >= MIN_VOTING_DELAY && votingDelay_ <= MAX_VOTING_DELAY, "GovernorBravo::initialize: invalid voting delay");
+        require(proposalThreshold_ >= MIN_PROPOSAL_THRESHOLD && proposalThreshold_ <= MAX_PROPOSAL_THRESHOLD, "GovernorBravo::initialize: invalid proposal threshold");
+
+        timelock = TimelockInterface(timelock_);
+        idle = IdleInterface(idle_);
+        votingPeriod = votingPeriod_;
+        votingDelay = votingDelay_;
+        proposalThreshold = proposalThreshold_;
+    }
+
+    /**
+      * @notice Function used to propose a new proposal. Sender must have delegates above the proposal threshold
+      * @param targets Target addresses for proposal calls
+      * @param values Eth values for proposal calls
+      * @param signatures Function signatures for proposal calls
+      * @param calldatas Calldatas for proposal calls
+      * @param description String description of the proposal
+      * @return Proposal id of new proposal
+      */
+    function propose(address[] memory targets, uint[] memory values, string[] memory signatures, bytes[] memory calldatas, string memory description) public returns (uint) {
+        // Reject proposals before initiating as Governor
+        require(initialProposalId != 0, "GovernorBravo::propose: Governor Bravo not active");
+        // Allow addresses above proposal threshold and whitelisted addresses to propose
+        require(idle.getPriorVotes(msg.sender, sub256(block.number, 1)) > proposalThreshold || isWhitelisted(msg.sender), "GovernorBravo::propose: proposer votes below proposal threshold");
+        require(targets.length == values.length && targets.length == signatures.length && targets.length == calldatas.length, "GovernorBravo::propose: proposal function information arity mismatch");
+        require(targets.length != 0, "GovernorBravo::propose: must provide actions");
+        require(targets.length <= proposalMaxOperations, "GovernorBravo::propose: too many actions");
+
+        uint latestProposalId = latestProposalIds[msg.sender];
+        if (latestProposalId != 0) {
+          ProposalState proposersLatestProposalState = state(latestProposalId);
+          require(proposersLatestProposalState != ProposalState.Active, "GovernorBravo::propose: one live proposal per proposer, found an already active proposal");
+          require(proposersLatestProposalState != ProposalState.Pending, "GovernorBravo::propose: one live proposal per proposer, found an already pending proposal");
+        }
+
+        uint startBlock = add256(block.number, votingDelay);
+        uint endBlock = add256(startBlock, votingPeriod);
+
+        proposalCount++;
+        Proposal memory newProposal = Proposal({
+            id: proposalCount,
+            proposer: msg.sender,
+            eta: 0,
+            targets: targets,
+            values: values,
+            signatures: signatures,
+            calldatas: calldatas,
+            startBlock: startBlock,
+            endBlock: endBlock,
+            forVotes: 0,
+            againstVotes: 0,
+            abstainVotes: 0,
+            canceled: false,
+            executed: false
+        });
+
+        proposals[newProposal.id] = newProposal;
+        latestProposalIds[newProposal.proposer] = newProposal.id;
+
+        emit ProposalCreated(newProposal.id, msg.sender, targets, values, signatures, calldatas, startBlock, endBlock, description);
+        return newProposal.id;
+    }
+
+    /**
+      * @notice Queues a proposal of state succeeded
+      * @param proposalId The id of the proposal to queue
+      */
+    function queue(uint proposalId) external {
+        require(state(proposalId) == ProposalState.Succeeded, "GovernorBravo::queue: proposal can only be queued if it is succeeded");
+        Proposal storage proposal = proposals[proposalId];
+        uint eta = add256(block.timestamp, timelock.delay());
+        for (uint i = 0; i < proposal.targets.length; i++) {
+            queueOrRevertInternal(proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], eta);
+        }
+        proposal.eta = eta;
+        emit ProposalQueued(proposalId, eta);
+    }
+
+    function queueOrRevertInternal(address target, uint value, string memory signature, bytes memory data, uint eta) internal {
+        require(!timelock.queuedTransactions(keccak256(abi.encode(target, value, signature, data, eta))), "GovernorBravo::queueOrRevertInternal: identical proposal action already queued at eta");
+        timelock.queueTransaction(target, value, signature, data, eta);
+    }
+
+    /**
+      * @notice Executes a queued proposal if eta has passed
+      * @param proposalId The id of the proposal to execute
+      */
+    function execute(uint proposalId) external payable {
+        require(state(proposalId) == ProposalState.Queued, "GovernorBravo::execute: proposal can only be executed if it is queued");
+        Proposal storage proposal = proposals[proposalId];
+        proposal.executed = true;
+        for (uint i = 0; i < proposal.targets.length; i++) {
+            timelock.executeTransaction.value(proposal.values[i])(proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], proposal.eta);
+        }
+        emit ProposalExecuted(proposalId);
+    }
+
+    /**
+      * @notice Cancels a proposal only if sender is the proposer, or proposer delegates dropped below proposal threshold
+      * @param proposalId The id of the proposal to cancel
+      */
+    function cancel(uint proposalId) external {
+        require(state(proposalId) != ProposalState.Executed, "GovernorBravo::cancel: cannot cancel executed proposal");
+
+        Proposal storage proposal = proposals[proposalId];
+
+        // Proposer can cancel
+        if(msg.sender != proposal.proposer) {
+            // Whitelisted proposers can't be canceled for falling below proposal threshold
+            if(isWhitelisted(proposal.proposer)) {
+                require((idle.getPriorVotes(proposal.proposer, sub256(block.number, 1)) < proposalThreshold) && msg.sender == whitelistGuardian, "GovernorBravo::cancel: whitelisted proposer");
+            }
+            else {
+                require((idle.getPriorVotes(proposal.proposer, sub256(block.number, 1)) < proposalThreshold), "GovernorBravo::cancel: proposer above threshold");
+            }
+        }
+        
+        proposal.canceled = true;
+        for (uint i = 0; i < proposal.targets.length; i++) {
+            timelock.cancelTransaction(proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], proposal.eta);
+        }
+
+        emit ProposalCanceled(proposalId);
+    }
+
+    /**
+      * @notice Gets actions of a proposal
+      * @param proposalId the id of the proposal
+      * @return Targets, values, signatures, and calldatas of the proposal actions
+      */
+    function getActions(uint proposalId) external view returns (address[] memory targets, uint[] memory values, string[] memory signatures, bytes[] memory calldatas) {
+        Proposal storage p = proposals[proposalId];
+        return (p.targets, p.values, p.signatures, p.calldatas);
+    }
+
+    /**
+      * @notice Gets the receipt for a voter on a given proposal
+      * @param proposalId the id of proposal
+      * @param voter The address of the voter
+      * @return The voting receipt
+      */
+    function getReceipt(uint proposalId, address voter) external view returns (Receipt memory) {
+        return proposals[proposalId].receipts[voter];
+    }
+
+    /**
+      * @notice Gets the state of a proposal
+      * @param proposalId The id of the proposal
+      * @return Proposal state
+      */
+    function state(uint proposalId) public view returns (ProposalState) {
+        require(proposalCount >= proposalId && proposalId > initialProposalId, "GovernorBravo::state: invalid proposal id");
+        Proposal storage proposal = proposals[proposalId];
+        if (proposal.canceled) {
+            return ProposalState.Canceled;
+        } else if (block.number <= proposal.startBlock) {
+            return ProposalState.Pending;
+        } else if (block.number <= proposal.endBlock) {
+            return ProposalState.Active;
+        } else if (proposal.forVotes <= proposal.againstVotes || proposal.forVotes < quorumVotes) {
+            return ProposalState.Defeated;
+        } else if (proposal.eta == 0) {
+            return ProposalState.Succeeded;
+        } else if (proposal.executed) {
+            return ProposalState.Executed;
+        } else if (block.timestamp >= add256(proposal.eta, timelock.GRACE_PERIOD())) {
+            return ProposalState.Expired;
+        } else {
+            return ProposalState.Queued;
+        }
+    }
+
+    /**
+      * @notice Cast a vote for a proposal
+      * @param proposalId The id of the proposal to vote on
+      * @param support The support value for the vote. 0=against, 1=for, 2=abstain
+      */
+    function castVote(uint proposalId, uint8 support) external {
+        emit VoteCast(msg.sender, proposalId, support, castVoteInternal(msg.sender, proposalId, support), "");
+    }
+
+    /**
+      * @notice Cast a vote for a proposal with a reason
+      * @param proposalId The id of the proposal to vote on
+      * @param support The support value for the vote. 0=against, 1=for, 2=abstain
+      * @param reason The reason given for the vote by the voter
+      */
+    function castVoteWithReason(uint proposalId, uint8 support, string calldata reason) external {
+        emit VoteCast(msg.sender, proposalId, support, castVoteInternal(msg.sender, proposalId, support), reason);
+    }
+
+    /**
+      * @notice Cast a vote for a proposal by signature
+      * @dev External function that accepts EIP-712 signatures for voting on proposals.
+      */
+    function castVoteBySig(uint proposalId, uint8 support, uint8 v, bytes32 r, bytes32 s) external {
+        bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(bytes(name)), getChainIdInternal(), address(this)));
+        bytes32 structHash = keccak256(abi.encode(BALLOT_TYPEHASH, proposalId, support));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+        address signatory = ecrecover(digest, v, r, s);
+        require(signatory != address(0), "GovernorBravo::castVoteBySig: invalid signature");
+        emit VoteCast(signatory, proposalId, support, castVoteInternal(signatory, proposalId, support), "");
+    }
+
+    /**
+      * @notice Internal function that caries out voting logic
+      * @param voter The voter that is casting their vote
+      * @param proposalId The id of the proposal to vote on
+      * @param support The support value for the vote. 0=against, 1=for, 2=abstain
+      * @return The number of votes cast
+      */
+    function castVoteInternal(address voter, uint proposalId, uint8 support) internal returns (uint96) {
+        require(state(proposalId) == ProposalState.Active, "GovernorBravo::castVoteInternal: voting is closed");
+        require(support <= 2, "GovernorBravo::castVoteInternal: invalid vote type");
+        Proposal storage proposal = proposals[proposalId];
+        Receipt storage receipt = proposal.receipts[voter];
+        require(receipt.hasVoted == false, "GovernorBravo::castVoteInternal: voter already voted");
+        uint96 votes = idle.getPriorVotes(voter, proposal.startBlock);
+
+        if (support == 0) {
+            proposal.againstVotes = add256(proposal.againstVotes, votes);
+        } else if (support == 1) {
+            proposal.forVotes = add256(proposal.forVotes, votes);
+        } else if (support == 2) {
+            proposal.abstainVotes = add256(proposal.abstainVotes, votes);
+        }
+
+        receipt.hasVoted = true;
+        receipt.support = support;
+        receipt.votes = votes;
+
+        return votes;
+    }
+
+    /**
+     * @notice View function which returns if an account is whitelisted
+     * @param account Account to check white list status of
+     * @return If the account is whitelisted
+     */
+    function isWhitelisted(address account) public view returns (bool) {
+        return (whitelistAccountExpirations[account] > now);
+    }
+
+    /**
+      * @notice Admin function for setting the voting delay
+      * @param newVotingDelay new voting delay, in blocks
+      */
+    function _setVotingDelay(uint newVotingDelay) external {
+        require(msg.sender == admin, "GovernorBravo::_setVotingDelay: admin only");
+        require(newVotingDelay >= MIN_VOTING_DELAY && newVotingDelay <= MAX_VOTING_DELAY, "GovernorBravo::_setVotingDelay: invalid voting delay");
+        uint oldVotingDelay = votingDelay;
+        votingDelay = newVotingDelay;
+
+        emit VotingDelaySet(oldVotingDelay,votingDelay);
+    }
+
+    /**
+      * @notice Admin function for setting the voting period
+      * @param newVotingPeriod new voting period, in blocks
+      */
+    function _setVotingPeriod(uint newVotingPeriod) external {
+        require(msg.sender == admin, "GovernorBravo::_setVotingPeriod: admin only");
+        require(newVotingPeriod >= MIN_VOTING_PERIOD && newVotingPeriod <= MAX_VOTING_PERIOD, "GovernorBravo::_setVotingPeriod: invalid voting period");
+        uint oldVotingPeriod = votingPeriod;
+        votingPeriod = newVotingPeriod;
+
+        emit VotingPeriodSet(oldVotingPeriod, votingPeriod);
+    }
+
+    /**
+      * @notice Admin function for setting the proposal threshold
+      * @dev newProposalThreshold must be greater than the hardcoded min
+      * @param newProposalThreshold new proposal threshold
+      */
+    function _setProposalThreshold(uint newProposalThreshold) external {
+        require(msg.sender == admin, "GovernorBravo::_setProposalThreshold: admin only");
+        require(newProposalThreshold >= MIN_PROPOSAL_THRESHOLD && newProposalThreshold <= MAX_PROPOSAL_THRESHOLD, "GovernorBravo::_setProposalThreshold: invalid proposal threshold");
+        uint oldProposalThreshold = proposalThreshold;
+        proposalThreshold = newProposalThreshold;
+
+        emit ProposalThresholdSet(oldProposalThreshold, proposalThreshold);
+    }
+
+    /**
+     * @notice Admin function for setting the whitelist expiration as a timestamp for an account. Whitelist status allows accounts to propose without meeting threshold
+     * @param account Account address to set whitelist expiration for
+     * @param expiration Expiration for account whitelist status as timestamp (if now < expiration, whitelisted)
+     */
+    function _setWhitelistAccountExpiration(address account, uint expiration) external {
+        require(msg.sender == admin || msg.sender == whitelistGuardian, "GovernorBravo::_setWhitelistAccountExpiration: admin only");
+        whitelistAccountExpirations[account] = expiration;
+
+        emit WhitelistAccountExpirationSet(account, expiration);
+    }
+
+    /**
+     * @notice Admin function for setting the whitelistGuardian. WhitelistGuardian can cancel proposals from whitelisted addresses
+     * @param account Account to set whitelistGuardian to (0x0 to remove whitelistGuardian)
+     */
+     function _setWhitelistGuardian(address account) external {
+        require(msg.sender == admin, "GovernorBravo::_setWhitelistGuardian: admin only");
+        address oldGuardian = whitelistGuardian;
+        whitelistGuardian = account;
+
+        emit WhitelistGuardianSet(oldGuardian, whitelistGuardian);
+     }
+
+    /**
+      * @notice Initiate the GovernorBravo contract
+      * @dev Admin only. Sets initial proposal id which initiates the contract, ensuring a continuous proposal id count
+      * @param governorAlpha The address for the Governor to continue the proposal id count from
+      */
+    function _initiate(address governorAlpha) external {
+        require(msg.sender == admin, "GovernorBravo::_initiate: admin only");
+        require(initialProposalId == 0, "GovernorBravo::_initiate: can only initiate once");
+        proposalCount = GovernorAlpha(governorAlpha).proposalCount();
+        initialProposalId = proposalCount;
+        timelock.acceptAdmin();
+    }
+
+    /**
+      * @notice Begins transfer of admin rights. The newPendingAdmin must call `_acceptAdmin` to finalize the transfer.
+      * @dev Admin function to begin change of admin. The newPendingAdmin must call `_acceptAdmin` to finalize the transfer.
+      * @param newPendingAdmin New pending admin.
+      */
+    function _setPendingAdmin(address newPendingAdmin) external {
+        // Check caller = admin
+        require(msg.sender == admin, "GovernorBravo:_setPendingAdmin: admin only");
+
+        // Save current value, if any, for inclusion in log
+        address oldPendingAdmin = pendingAdmin;
+
+        // Store pendingAdmin with value newPendingAdmin
+        pendingAdmin = newPendingAdmin;
+
+        // Emit NewPendingAdmin(oldPendingAdmin, newPendingAdmin)
+        emit NewPendingAdmin(oldPendingAdmin, newPendingAdmin);
+    }
+
+    /**
+      * @notice Accepts transfer of admin rights. msg.sender must be pendingAdmin
+      * @dev Admin function for pending admin to accept role and update admin
+      */
+    function _acceptAdmin() external {
+        // Check caller is pendingAdmin and pendingAdmin ≠ address(0)
+        require(msg.sender == pendingAdmin && msg.sender != address(0), "GovernorBravo:_acceptAdmin: pending admin only");
+
+        // Save current values for inclusion in log
+        address oldAdmin = admin;
+        address oldPendingAdmin = pendingAdmin;
+
+        // Store admin with value pendingAdmin
+        admin = pendingAdmin;
+
+        // Clear the pending value
+        pendingAdmin = address(0);
+
+        emit NewAdmin(oldAdmin, admin);
+        emit NewPendingAdmin(oldPendingAdmin, pendingAdmin);
+    }
+
+    function add256(uint256 a, uint256 b) internal pure returns (uint) {
+        uint c = a + b;
+        require(c >= a, "addition overflow");
+        return c;
+    }
+
+    function sub256(uint256 a, uint256 b) internal pure returns (uint) {
+        require(b <= a, "subtraction underflow");
+        return a - b;
+    }
+
+    function getChainIdInternal() internal pure returns (uint) {
+        uint chainId;
+        assembly { chainId := chainid() }
+        return chainId;
+    }
+}

--- a/contracts/GovernorBravoDelegate.sol
+++ b/contracts/GovernorBravoDelegate.sol
@@ -30,7 +30,7 @@ contract GovernorBravoDelegate is GovernorBravoDelegateStorageV2, GovernorBravoE
     uint public constant quorumVotes = 520000e18; // 520,000 = 4% of Idle max supply
 
     /// @notice The maximum number of actions that can be included in a proposal
-    uint public constant proposalMaxOperations = 10; // 10 actions
+    uint public constant proposalMaxOperations = 15; // 15 actions
 
     /// @notice The EIP-712 typehash for the contract's domain
     bytes32 public constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");

--- a/contracts/GovernorBravoDelegate.sol
+++ b/contracts/GovernorBravoDelegate.sol
@@ -9,10 +9,10 @@ contract GovernorBravoDelegate is GovernorBravoDelegateStorageV2, GovernorBravoE
     string public constant name = "Idle Governor Bravo";
 
     /// @notice The minimum setable proposal threshold
-    uint public constant MIN_PROPOSAL_THRESHOLD = 65000e18; // 65,000 Idle
+    uint public constant MIN_PROPOSAL_THRESHOLD = 65000e18; // 65,000 Idle (.5% of max supply)
 
     /// @notice The maximum setable proposal threshold
-    uint public constant MAX_PROPOSAL_THRESHOLD = 130000e18; //130,000 Idle
+    uint public constant MAX_PROPOSAL_THRESHOLD = 130000e18; //130,000 Idle (1% of max supply)
 
     /// @notice The minimum setable voting period
     uint public constant MIN_VOTING_PERIOD = 5760; // About 24 hours
@@ -27,7 +27,7 @@ contract GovernorBravoDelegate is GovernorBravoDelegateStorageV2, GovernorBravoE
     uint public constant MAX_VOTING_DELAY = 40320; // About 1 week
 
     /// @notice The number of votes in support of a proposal required in order for a quorum to be reached and for a vote to succeed
-    uint public constant quorumVotes = 520000e18; // 520,000 = 4% of Idle
+    uint public constant quorumVotes = 520000e18; // 520,000 = 4% of Idle max supply
 
     /// @notice The maximum number of actions that can be included in a proposal
     uint public constant proposalMaxOperations = 10; // 10 actions

--- a/contracts/GovernorBravoDelegate.sol
+++ b/contracts/GovernorBravoDelegate.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.16;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "./GovernorBravoInterfaces.sol";
@@ -144,7 +144,7 @@ contract GovernorBravoDelegate is GovernorBravoDelegateStorageV2, GovernorBravoE
         Proposal storage proposal = proposals[proposalId];
         proposal.executed = true;
         for (uint i = 0; i < proposal.targets.length; i++) {
-            timelock.executeTransaction.value(proposal.values[i])(proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], proposal.eta);
+            timelock.executeTransaction{value: proposal.values[i]}(proposal.targets[i], proposal.values[i], proposal.signatures[i], proposal.calldatas[i], proposal.eta);
         }
         emit ProposalExecuted(proposalId);
     }
@@ -180,7 +180,10 @@ contract GovernorBravoDelegate is GovernorBravoDelegateStorageV2, GovernorBravoE
     /**
       * @notice Gets actions of a proposal
       * @param proposalId the id of the proposal
-      * @return Targets, values, signatures, and calldatas of the proposal actions
+      * @return targets of the proposal actions
+      * @return values of the proposal actions
+      * @return signatures of the proposal actions
+      * @return calldatas of the proposal actions
       */
     function getActions(uint proposalId) external view returns (address[] memory targets, uint[] memory values, string[] memory signatures, bytes[] memory calldatas) {
         Proposal storage p = proposals[proposalId];

--- a/contracts/GovernorBravoDelegator.sol
+++ b/contracts/GovernorBravoDelegator.sol
@@ -53,7 +53,7 @@ contract GovernorBravoDelegator is GovernorBravoDelegatorStorage, GovernorBravoE
         (bool success, bytes memory returnData) = callee.delegatecall(data);
         assembly {
             if eq(success, 0) {
-                revert(add(returnData, 0x20), returndatasize)
+                revert(add(returnData, 0x20), returndatasize())
             }
         }
     }
@@ -63,17 +63,17 @@ contract GovernorBravoDelegator is GovernorBravoDelegatorStorage, GovernorBravoE
      * It returns to the external caller whatever the implementation returns
      * or forwards reverts.
      */
-    function () external payable {
+    fallback() external payable {
         // delegate all other functions to current implementation
         (bool success, ) = implementation.delegatecall(msg.data);
 
         assembly {
               let free_mem_ptr := mload(0x40)
-              returndatacopy(free_mem_ptr, 0, returndatasize)
+              returndatacopy(free_mem_ptr, 0, returndatasize())
 
               switch success
-              case 0 { revert(free_mem_ptr, returndatasize) }
-              default { return(free_mem_ptr, returndatasize) }
+              case 0 { revert(free_mem_ptr, returndatasize()) }
+              default { return(free_mem_ptr, returndatasize()) }
         }
     }
 }

--- a/contracts/GovernorBravoDelegator.sol
+++ b/contracts/GovernorBravoDelegator.sol
@@ -1,0 +1,79 @@
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "./GovernorBravoInterfaces.sol";
+
+contract GovernorBravoDelegator is GovernorBravoDelegatorStorage, GovernorBravoEvents {
+	constructor(
+			address timelock_,
+			address idle_,
+			address admin_,
+	        address implementation_,
+	        uint votingPeriod_,
+	        uint votingDelay_,
+            uint proposalThreshold_) public {
+
+        // Admin set to msg.sender for initialization
+        admin = msg.sender;
+
+        delegateTo(implementation_, abi.encodeWithSignature("initialize(address,address,uint256,uint256,uint256)",
+                                                            timelock_,
+                                                            idle_,
+                                                            votingPeriod_,
+                                                            votingDelay_,
+                                                            proposalThreshold_));
+
+        _setImplementation(implementation_);
+
+		admin = admin_;
+	}
+
+
+	/**
+     * @notice Called by the admin to update the implementation of the delegator
+     * @param implementation_ The address of the new implementation for delegation
+     */
+    function _setImplementation(address implementation_) public {
+        require(msg.sender == admin, "GovernorBravoDelegator::_setImplementation: admin only");
+        require(implementation_ != address(0), "GovernorBravoDelegator::_setImplementation: invalid implementation address");
+
+        address oldImplementation = implementation;
+        implementation = implementation_;
+
+        emit NewImplementation(oldImplementation, implementation);
+    }
+
+    /**
+     * @notice Internal method to delegate execution to another contract
+     * @dev It returns to the external caller whatever the implementation returns or forwards reverts
+     * @param callee The contract to delegatecall
+     * @param data The raw data to delegatecall
+     */
+    function delegateTo(address callee, bytes memory data) internal {
+        (bool success, bytes memory returnData) = callee.delegatecall(data);
+        assembly {
+            if eq(success, 0) {
+                revert(add(returnData, 0x20), returndatasize)
+            }
+        }
+    }
+
+	/**
+     * @dev Delegates execution to an implementation contract.
+     * It returns to the external caller whatever the implementation returns
+     * or forwards reverts.
+     */
+    function () external payable {
+        // delegate all other functions to current implementation
+        (bool success, ) = implementation.delegatecall(msg.data);
+
+        assembly {
+              let free_mem_ptr := mload(0x40)
+              returndatacopy(free_mem_ptr, 0, returndatasize)
+
+              switch success
+              case 0 { revert(free_mem_ptr, returndatasize) }
+              default { return(free_mem_ptr, returndatasize) }
+        }
+    }
+}

--- a/contracts/GovernorBravoInterfaces.sol
+++ b/contracts/GovernorBravoInterfaces.sol
@@ -1,0 +1,196 @@
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+
+contract GovernorBravoEvents {
+    /// @notice An event emitted when a new proposal is created
+    event ProposalCreated(uint id, address proposer, address[] targets, uint[] values, string[] signatures, bytes[] calldatas, uint startBlock, uint endBlock, string description);
+
+    /// @notice An event emitted when a vote has been cast on a proposal
+    /// @param voter The address which casted a vote
+    /// @param proposalId The proposal id which was voted on
+    /// @param support Support value for the vote. 0=against, 1=for, 2=abstain
+    /// @param votes Number of votes which were cast by the voter
+    /// @param reason The reason given for the vote by the voter
+    event VoteCast(address indexed voter, uint proposalId, uint8 support, uint votes, string reason);
+
+    /// @notice An event emitted when a proposal has been canceled
+    event ProposalCanceled(uint id);
+
+    /// @notice An event emitted when a proposal has been queued in the Timelock
+    event ProposalQueued(uint id, uint eta);
+
+    /// @notice An event emitted when a proposal has been executed in the Timelock
+    event ProposalExecuted(uint id);
+
+    /// @notice An event emitted when the voting delay is set
+    event VotingDelaySet(uint oldVotingDelay, uint newVotingDelay);
+
+    /// @notice An event emitted when the voting period is set
+    event VotingPeriodSet(uint oldVotingPeriod, uint newVotingPeriod);
+
+    /// @notice Emitted when implementation is changed
+    event NewImplementation(address oldImplementation, address newImplementation);
+
+    /// @notice Emitted when proposal threshold is set
+    event ProposalThresholdSet(uint oldProposalThreshold, uint newProposalThreshold);
+
+    /// @notice Emitted when pendingAdmin is changed
+    event NewPendingAdmin(address oldPendingAdmin, address newPendingAdmin);
+
+    /// @notice Emitted when pendingAdmin is accepted, which means admin is updated
+    event NewAdmin(address oldAdmin, address newAdmin);
+
+    /// @notice Emitted when whitelist account expiration is set
+    event WhitelistAccountExpirationSet(address account, uint expiration);
+
+    /// @notice Emitted when the whitelistGuardian is set
+    event WhitelistGuardianSet(address oldGuardian, address newGuardian);
+}
+
+contract GovernorBravoDelegatorStorage {
+    /// @notice Administrator for this contract
+    address public admin;
+
+    /// @notice Pending administrator for this contract
+    address public pendingAdmin;
+
+    /// @notice Active brains of Governor
+    address public implementation;
+}
+
+
+/**
+ * @title Storage for Governor Bravo Delegate
+ * @notice For future upgrades, do not change GovernorBravoDelegateStorageV1. Create a new
+ * contract which implements GovernorBravoDelegateStorageV1 and following the naming convention
+ * GovernorBravoDelegateStorageVX.
+ */
+contract GovernorBravoDelegateStorageV1 is GovernorBravoDelegatorStorage {
+
+    /// @notice The delay before voting on a proposal may take place, once proposed, in blocks
+    uint public votingDelay;
+
+    /// @notice The duration of voting on a proposal, in blocks
+    uint public votingPeriod;
+
+    /// @notice The number of votes required in order for a voter to become a proposer
+    uint public proposalThreshold;
+
+    /// @notice Initial proposal id set at become
+    uint public initialProposalId;
+
+    /// @notice The total number of proposals
+    uint public proposalCount;
+
+    /// @notice The address of the Idle Protocol Timelock
+    TimelockInterface public timelock;
+
+    /// @notice The address of the Idle governance token
+    IdleInterface public idle;
+
+    /// @notice The official record of all proposals ever proposed
+    mapping (uint => Proposal) public proposals;
+
+    /// @notice The latest proposal for each proposer
+    mapping (address => uint) public latestProposalIds;
+
+
+    struct Proposal {
+        /// @notice Unique id for looking up a proposal
+        uint id;
+
+        /// @notice Creator of the proposal
+        address proposer;
+
+        /// @notice The timestamp that the proposal will be available for execution, set once the vote succeeds
+        uint eta;
+
+        /// @notice the ordered list of target addresses for calls to be made
+        address[] targets;
+
+        /// @notice The ordered list of values (i.e. msg.value) to be passed to the calls to be made
+        uint[] values;
+
+        /// @notice The ordered list of function signatures to be called
+        string[] signatures;
+
+        /// @notice The ordered list of calldata to be passed to each call
+        bytes[] calldatas;
+
+        /// @notice The block at which voting begins: holders must delegate their votes prior to this block
+        uint startBlock;
+
+        /// @notice The block at which voting ends: votes must be cast prior to this block
+        uint endBlock;
+
+        /// @notice Current number of votes in favor of this proposal
+        uint forVotes;
+
+        /// @notice Current number of votes in opposition to this proposal
+        uint againstVotes;
+
+        /// @notice Current number of votes for abstaining for this proposal
+        uint abstainVotes;
+
+        /// @notice Flag marking whether the proposal has been canceled
+        bool canceled;
+
+        /// @notice Flag marking whether the proposal has been executed
+        bool executed;
+
+        /// @notice Receipts of ballots for the entire set of voters
+        mapping (address => Receipt) receipts;
+    }
+
+    /// @notice Ballot receipt record for a voter
+    struct Receipt {
+        /// @notice Whether or not a vote has been cast
+        bool hasVoted;
+
+        /// @notice Whether or not the voter supports the proposal or abstains
+        uint8 support;
+
+        /// @notice The number of votes the voter had, which were cast
+        uint96 votes;
+    }
+
+    /// @notice Possible states that a proposal may be in
+    enum ProposalState {
+        Pending,
+        Active,
+        Canceled,
+        Defeated,
+        Succeeded,
+        Queued,
+        Expired,
+        Executed
+    }
+}
+
+contract GovernorBravoDelegateStorageV2 is GovernorBravoDelegateStorageV1 {
+    /// @notice Stores the expiration of account whitelist status as a timestamp
+    mapping (address => uint) public whitelistAccountExpirations;
+
+    /// @notice Address which manages whitelisted proposals and whitelist accounts
+    address public whitelistGuardian;
+}
+
+interface TimelockInterface {
+    function delay() external view returns (uint);
+    function GRACE_PERIOD() external view returns (uint);
+    function acceptAdmin() external;
+    function queuedTransactions(bytes32 hash) external view returns (bool);
+    function queueTransaction(address target, uint value, string calldata signature, bytes calldata data, uint eta) external returns (bytes32);
+    function cancelTransaction(address target, uint value, string calldata signature, bytes calldata data, uint eta) external;
+    function executeTransaction(address target, uint value, string calldata signature, bytes calldata data, uint eta) external payable returns (bytes memory);
+}
+
+interface IdleInterface {
+    function getPriorVotes(address account, uint blockNumber) external view returns (uint96);
+}
+
+interface GovernorAlpha {
+    /// @notice The total number of proposals
+    function proposalCount() external returns (uint);
+}

--- a/migrations/7_deploy_governor_bravo.js
+++ b/migrations/7_deploy_governor_bravo.js
@@ -1,0 +1,44 @@
+const GovernorBravoDelegate = artifacts.require("GovernorBravoDelegate")
+const GovernorBravoDelegator = artifacts.require("GovernorBravoDelegator")
+const BigNumber = require('bignumber.js');
+
+const BNify = s => new BigNumber(s);
+
+module.exports = async function (deployer, network, accounts) {
+    if (network === 'test' || network == 'coverage') {
+        return;
+    }
+
+    const addresses = {
+        timelock: '0xD6dABBc2b275114a2366555d6C481EF08FDC2556',
+        idle: '0x875773784Af8135eA0ef43b5a374AaD105c5D39e',
+        multisig: '0xe8eA8bAE250028a8709A3841E0Ae1a44820d677b' 
+    }
+
+    const args = { // args from GovernorAlpha
+        votingPeriod: '17280',
+        votingDelay: '1',
+        proposalThreshold: '130000000000000000000000'
+    }
+
+    const creator = accounts[0];
+
+    await deployer.then(async () => {
+        const delegate = await GovernorBravoDelegate.new({from: creator, gas: BNify('5000000')});
+        
+        console.log('Delegate deployed at: ' + delegate.address);
+
+        const delegator = await GovernorBravoDelegator.new(
+            addresses.timelock, 
+            addresses.idle, 
+            addresses.multisig, 
+            delegate.address, 
+            BNify(args.votingPeriod),
+            BNify(args.votingDelay),
+            BNify(args.proposalThreshold),
+            {from: creator, gas: BNify('700000')}
+        );
+        
+        console.log('Delegator deployed at: ' + delegator.address);
+    });
+}


### PR DESCRIPTION
This PR implements the following RFP: 

```
RFP-13: Upgrade Idle Governor Alpha to Compound Governor Bravo

Here is more info on Alpha vs Bravo: 
https://medium.com/tally-blog/understanding-governor-bravo-69b06f1875da
Current parameters for quorum, min balance for proposals etc should be ported to Bravo
```

**What's left to do**

A deploy script is needed to deploy and initiate the GovernorBravo contract. Steps would be:

- Deploy the `GovernorBravoDelegate.sol` contract
- Deploy the `GovernorBravoDelegator.sol` with these arguments: 
```
TIMELOCK_ADDRESS = 0xd6dabbc2b275114a2366555d6c481ef08fdc2556
IDLE_ADDRESS = 0x875773784af8135ea0ef43b5a374aad105c5d39e
VOTING_PERIOD = 17280
VOTING_DELAY = 1
PROPOSAL_THRESHOLD = 130000000000000000000000

{timelock_: TIMELOCK_ADDRESS, idle_: IDLE_ADDRESS, admin_: ADMIN, implementation_: GOVERNOR_BRAVO_DELEGATE_ADDRESS, votingPeriod_: VOTING_PERIOD, votingDelay_: VOTING_DELAY, proposalThreshold_: PROPOSAL_THRESHOLD}
```
- Call `GOVERNOR_BRAVO._initiate(GOVERNOR_ALPHA)` where `GOVERNOR_BRAVO` is the deployed Governor Bravo and `GOVERNOR_ALPHA` is `0x2256b25CFC8E35c3135664FD03E77595042fe31B` (the actual Governor Alpha).